### PR TITLE
Add help email to and webpage to getFIA.Rd

### DIFF
--- a/man/getFIA.Rd
+++ b/man/getFIA.Rd
@@ -36,6 +36,10 @@ If multiple subsets of the FIA database are downloaded (e.g. \code{states = c('M
 \references{
 FIA DataMart: \url{https://apps.fs.usda.gov/fia/datamart/datamart.html}
 
+FIA Website Questions: \url{https://www.fia.fs.fed.us/about/about_us/#website_q}
+Direct email: SM.FS.fia@usda.gov 
+E.g., Problems accessing the state CSV files.
+                            
 FIA Database User Guide: \url{https://www.fia.fs.fed.us/library/database-documentation/}
 }
 


### PR DESCRIPTION
Add web page and email address for requesting help with any issues on FIA Program website. 

In this case, I discovered today that access to the state-level CSV files on DataMart were broken. Emailed and they are already working on it (quick response), though it may take a day or so.